### PR TITLE
Fix about:XXX url support in Firefox

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,10 +22,12 @@ module.exports = class extends URL {
     constructor(url, base) {
         try {
             super(url, base);
+            Object.defineProperty(this, "isValid", { get: () => true });
         } catch {
             // For all invalid input, initialize fields with guaranteed invalid host
             // https://serverfault.com/a/846523
             super("http://invalid.invalid");
+            Object.defineProperty(this, "isValid", { get: () => false });
         }
 
         // if no port is defined, but the protocol port is known, set the port to that

--- a/index.js
+++ b/index.js
@@ -20,11 +20,12 @@ module.exports = class extends URL {
      * @param string base Base URL
      */
     constructor(url, base) {
-        super(url, base);
-
-        // workaround for firefox bug
-        if (this.origin === "null") {
-            Object.defineProperty(this, "origin", {get: () => null});
+        try {
+            super(url, base);
+        } catch {
+            // For all invalid input, initialize fields with guaranteed invalid host
+            // https://serverfault.com/a/846523
+            super("http://invalid.invalid");
         }
 
         // if no port is defined, but the protocol port is known, set the port to that

--- a/index.js
+++ b/index.js
@@ -22,12 +22,12 @@ module.exports = class extends URL {
     constructor(url, base) {
         try {
             super(url, base);
-            Object.defineProperty(this, "isValid", { get: () => true });
+            Object.defineProperty(this, "isValid", { value: true, writable: false });
         } catch {
             // For all invalid input, initialize fields with guaranteed invalid host
             // https://serverfault.com/a/846523
             super("http://invalid.invalid");
-            Object.defineProperty(this, "isValid", { get: () => false });
+            Object.defineProperty(this, "isValid", { value: false, writable: false });
         }
 
         // if no port is defined, but the protocol port is known, set the port to that

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@browserpass/url",
-    "version": "1.1.5",
+    "version": "1.1.6",
     "description": "Extended URL class with domain analysis",
     "homepage": "https://github.com/browserpass/browserpass-url",
     "repository": "github:browserpass/browserpass-url",


### PR DESCRIPTION
@erayd what do you think about the following hacky solution?

The current workaround doesn't work because an exception is being thrown during `super` call, but here I will simply catch all exceptions and initialize the object based on an guaranteed invalid host, this way we don't need to check any null-values in browserpass code.