### PR TITLE
Convert internationalized domain names to their Unicode form

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const punycode = require("punycode");
+const punycode = require("punycode.js");
 const { tldList } = require("./tld.js");
 
 // protocol -> port mapping

--- a/index.js
+++ b/index.js
@@ -73,7 +73,6 @@ module.exports = class extends URL {
  * @return boolean
  */
 function isTLD(hostname) {
-    hostname = punycode.toUnicode(hostname);
     let isTLD = tldList.includes(hostname);
     if (!isTLD) {
         isTLD = tldList.includes(`*.${hostname}`);
@@ -90,6 +89,10 @@ function isTLD(hostname) {
  * @param string hostname Hostname
  */
 function getComponents(hostname) {
+    // Convert potential Punycode hostname to Unicode
+    // This won't have any effect if it already is in Unicode
+    hostname = punycode.toUnicode(hostname);
+
     let components = {
         hostname,
         tld: null,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     ],
     "main": "index.js",
     "dependencies": {
-        "punycode": "^2.1.1"
+        "punycode.js": "^2.3.1"
     },
     "devDependencies": {
         "prettier": "^1.16.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,7 +7,7 @@ prettier@^1.16.4:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
   integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
 
-punycode@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
-  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+punycode.js@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/punycode.js/-/punycode.js-2.3.1.tgz#6b53e56ad75588234e79f4affa90972c7dd8cdb7"
+  integrity sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==


### PR DESCRIPTION
This makes it so that all internationalized domain names are always converted from Punycode to their Unicode versions.
E.g., `xn--gnstigekchen-dlbh.at` -> `günstigeküchen.at`

This should have no unintended side effects, as a domain name that already is in Unicode will not be modified in any way.

I have also taken the liberty to update [punycode.js](https://github.com/mathiasbynens/punycode.js) to the latest version and I have changed the dependency name from `punycode` to `punycode.js`; the library is published on npm under both names and the latter makes it less likely to confuse it with the deprecated Node.js core module of the same
name. See [here](https://github.com/mathiasbynens/punycode.js/issues/122) for some more information on this.

~~Interestingly, while we agreed that it's not necessary to keep supporting password store entries that have a Punycode name, it continues to work.~~

~~I guess it's fine if that still works too, but I haven't been able to figure out why that is the case; I will try to investigate some more and figure it out (and then we could still decide to explicitly remove this feature if we want to).~~

__Edit:__ I just realized that was only because of the cache since I had used the Punycode entry on my example website before.

---

To easily test these changes in [browserpass-extension](https://github.com/browserpass/browserpass-extension/), override the dependency like this:
```diff
diff --git a/src/package.json b/src/package.json
index 16a0e86..f63e135 100644
--- a/src/package.json
+++ b/src/package.json
@@ -15,7 +15,7 @@
         }
     ],
     "dependencies": {
-        "@browserpass/url": "^1.1.6",
+        "@browserpass/url": "git+https://github.com/mserajnik/browserpass-url.git#handle-punycode",
         "chrome-extension-async": "^3.4.1",
         "fuzzysort": "^1.1.4",
         "hash.js": "^1.1.7",
```
And then run `rm -rf src/node_modules/ src/yarn.lock ; make` and reload the unpacked extension.

~~This schould close https://github.com/browserpass/browserpass-extension/issues/389 once it is merged and browserpass-extension gets updated to use the updated browserpass-url.~~
~~__Edit 2:__ I have noticed that the badge counter doesn't work for IDNs; so I will probably still need to make some adjustment in browserpass-extension.~~
__Edit 3:__ Never mind, it appears to work after all, it's just not necessarily always updating instantly as I might have expected.